### PR TITLE
Specify scheme in library.properties url value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=justin@ufire.co
 sentence=An Ion Specific Electrode Probe Interface
 paragraph=Use it to measure pH, ORP, or any other voltage based probe
 category=Sensors
-url=ufire.co
+url=http://ufire.co
 architectures=*


### PR DESCRIPTION
The library.properties `url` property is used by the Arduino IDE to add a clickable "More info" link to the Library Manager entry for each library. The scheme must be specified in order for this link to be clickable.