### PR TITLE
Use semver compliant version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ISE Probe Interface
-version=1.1.00
+version=1.1.0
 author=Justin Decker
 maintainer=justin@ufire.co
 sentence=An Ion Specific Electrode Probe Interface


### PR DESCRIPTION
Non-semver compliant `version` value causes the Arduino IDE to display warnings:
```
Invalid version found: 1.0.00
```
This can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

References:
- https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format
- https://semver.org/